### PR TITLE
Consume entire value when decoding

### DIFF
--- a/src/Data/Aeson/Utils.hs
+++ b/src/Data/Aeson/Utils.hs
@@ -13,12 +13,14 @@ module Data.Aeson.Utils
   , floatingOrInteger
   ) where
 
+import Control.Applicative ((<*))
 import Data.Aeson
 import Data.Aeson.Parser (value)
 import Data.Aeson.Types
 import Data.Attoparsec.Lazy (Result (..))
 import Data.Scientific
 import Data.Text (Text)
+import qualified Data.Attoparsec.ByteString.Char8 as Atto (skipSpace)
 import qualified Data.Attoparsec.Lazy as Atto
 import qualified Data.ByteString.Lazy as L
 
@@ -26,7 +28,7 @@ import qualified Data.ByteString.Lazy as L
 
 -- | Like 'decodeV', but returns an error message when decoding fails.
 eitherDecodeV :: FromJSON a => L.ByteString -> Either String a
-eitherDecodeV v = case Atto.parse value v of
+eitherDecodeV v = case Atto.parse (value <* Atto.skipSpace <* Atto.endOfInput) v of
   Fail _ _ err -> Left err
   Done _ r     -> case fromJSON r of
     Error e   -> Left e


### PR DESCRIPTION
See comment on commit.

This is useful to have, but it does change the semantics of decoding. So, you may also consider having a separate function for this.